### PR TITLE
Change threading-mode to runtime-mode for granian

### DIFF
--- a/galleries/code-gallery/README.md
+++ b/galleries/code-gallery/README.md
@@ -34,7 +34,7 @@ granian talkpython.quart_app:app \
        --interface asgi \ 
        --no-ws 
        --workers 3 \
-       --threading-mode workers \
+       --runtime-mode st \
        --loop uvloop \
        --workers-lifetime 43200 --respawn-interval 30 \
        --process-name "granian-talkpython" \
@@ -55,7 +55,7 @@ ENTRYPOINT [  \
   "--interface","asgi", \
   "--no-ws", \
   "--workers","3", \
-  "--threading-mode", "workers", \
+  "--runtime-mode", "st", \
   "--loop","uvloop", \
   "--log-level","info",\
   "--log", \


### PR DESCRIPTION
In granian 2.0 `threading-mode workers` was removed in favor of `runtime-mode st`. https://github.com/emmett-framework/granian/releases/tag/v2.0.0

I'm not sure how much this would affect the rest of the book so it may make more sense not to merge this and just make a note of the change.